### PR TITLE
Handle Galaxy Config initialized with empty config.

### DIFF
--- a/src/main/java/com/nesscomputing/httpserver/log/syslog/SyslogRequestLog.java
+++ b/src/main/java/com/nesscomputing/httpserver/log/syslog/SyslogRequestLog.java
@@ -133,8 +133,12 @@ public class SyslogRequestLog extends AbstractLifeCycle implements RequestLog
         builderMap.put("l@" + ianaIdentifier, logBuilder);
 
         if (galaxyConfig != null) {
-            logBuilder.put("si", String.valueOf(galaxyConfig.getEnv().getAgentId()));
-            logBuilder.put("sc", String.valueOf(galaxyConfig.getDeploy().getConfig()));
+            if (galaxyConfig.getEnv().getAgentId() != null) {
+                logBuilder.put("si", galaxyConfig.getEnv().getAgentId());
+            }
+            if (galaxyConfig.getDeploy().getConfig() != null) {
+                logBuilder.put("sc", galaxyConfig.getDeploy().getConfig());
+            }
         }
 
         for (Iterator<String> it = logFields.iterator(); it.hasNext(); ) {

--- a/src/main/java/com/nesscomputing/httpserver/log/syslog/SyslogRequestLog.java
+++ b/src/main/java/com/nesscomputing/httpserver/log/syslog/SyslogRequestLog.java
@@ -133,8 +133,8 @@ public class SyslogRequestLog extends AbstractLifeCycle implements RequestLog
         builderMap.put("l@" + ianaIdentifier, logBuilder);
 
         if (galaxyConfig != null) {
-            logBuilder.put("si", galaxyConfig.getEnv().getAgentId());
-            logBuilder.put("sc", galaxyConfig.getDeploy().getConfig());
+            logBuilder.put("si", String.valueOf(galaxyConfig.getEnv().getAgentId()));
+            logBuilder.put("sc", String.valueOf(galaxyConfig.getDeploy().getConfig()));
         }
 
         for (Iterator<String> it = logFields.iterator(); it.hasNext(); ) {

--- a/src/test/java/com/nesscomputing/httpserver/log/syslog/SyslogRequestLogTest.java
+++ b/src/test/java/com/nesscomputing/httpserver/log/syslog/SyslogRequestLogTest.java
@@ -139,7 +139,7 @@ public class SyslogRequestLogTest extends EasyMockSupport
         });
     }
 
-    public void testMockRequest(Module extra)
+    private void testMockRequest(Module extra)
     {
         final Config config = Config.getFixedConfig("ness.httpserver.request-log.syslog.enabled", "true",
                                                     "ness.httpserver.request-log.syslog.protocol", "fake");


### PR DESCRIPTION
When GalaxyConfig is initialized with an empty config, the values passed to the logger are null, failing a precondition.
